### PR TITLE
Moved partitions to global and updated LRU set methods. Added a metho…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,9 @@ go get github.com/vivek07672/spectre
 import "github.com/vivek07672/spectre"
 
 // so the first step is to get the cache variable
-volatileLRUCache := volatileLRUCache.GetVolatileLRUCache(cacheSize int, cachePartitions int, ttl time.Duration)
+volatileLRUCache := volatileLRUCache.GetVolatileLRUCache(cacheSize int, ttl time.Duration)
 the parameters :
 	cacheSize: size of ram memory in bytes that is to be allocated to the cache
-	cachePartitions: no of internal maps to be used
-				- larger the number better thread safe (32 is a good count )
-			 inside total this many maps are kept to cache the date , each map can give access to 
-			 one goroutine at any time .
 	ttl: a global timeout for all the keys
 	
 // now its time for some operation testing

--- a/cache.go
+++ b/cache.go
@@ -10,7 +10,7 @@ import (
 
 // SHARD_COUNT is the number of golang maps that are going to participate in caching
 // internally.
-var SHARD_COUNT int
+var SHARD_COUNT int = 256
 
 // lowSpaceError is the error that is thrown when the cache object is capable of
 // caching the given value ,but the cache object is running out of memory.
@@ -304,8 +304,7 @@ func (c *Cache) ClearCache() {
 // GetDefaultCache returns the most abstract cache just using the
 // cap in memory limit . Cache is having algorithm to evict key when
 // space is not available in random selection.
-func GetDefaultCache(cacheSize int, cachePartitions int) *Cache {
-	SHARD_COUNT = cachePartitions
+func GetDefaultCache(cacheSize int) *Cache {
 	newCache := &Cache{
 		Data: &cacheData{MapList: make([]*threadSafeMap, SHARD_COUNT)},
 		Size: make(map[string]int),

--- a/cache_test.go
+++ b/cache_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-var testCache = GetDefaultCache(5000, 15)
+var testCache = GetDefaultCache(5000)
 
 func TestGetCurrentSize(t *testing.T) {
 	var size = 0

--- a/volatileLRUCache_test.go
+++ b/volatileLRUCache_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-var VolatileLRUCacheTest = GetVolatileLRUCache(50000.0, 15, time.Duration(3600))
+var VolatileLRUCacheTest = GetVolatileLRUCache(50000.0, time.Duration(3600))
 
 func TestVolatileLRUCacheCurrentSize(t *testing.T) {
 	var size = 0


### PR DESCRIPTION
…d to do set at cache, in case memory is full it doe not set for time being. This mode to be used, when spectre is used for too frequent sets and LRUed at very high rate. This will overcome cache limit of 1 million records and extend further. while making space, it is deleting 30% of cache size ratehr than 50 % size